### PR TITLE
extending Subscriber options with offsetNewest flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,6 +266,7 @@ class Subscriber {
       this.uaaUrl = options.uaaUrl;
       this.clientId = options.clientId;
       this.clientSecret = options.clientSecret;
+      this.offsetNewest = options.offsetNewest || false;
     } else {
       throw new Error('Required options missing, see debug log');
     }
@@ -277,6 +278,9 @@ class Subscriber {
    */
   get stream() {
     // Create a new subscription and return the raw stream
+    const metadata = new grpc.Metadata();
+    metadata.add('offset-newest', this.offsetNewest.toString());
+
     const creds = getCreds(this.uaaUrl, this.clientId, this.clientSecret, this.zoneIdProp, this.zoneId);
     const client = new eventhub_proto.Subscriber(this.uri, creds);
 
@@ -286,7 +290,7 @@ class Subscriber {
       zone_id: this.zoneId,
       subscriber: this.name,
       instance_id: this.instance
-    });
+    }, metadata);
 
     s.on('close', () => {
       debug('Subscribe stream closed');

--- a/index.js
+++ b/index.js
@@ -266,6 +266,7 @@ class Subscriber {
       this.uaaUrl = options.uaaUrl;
       this.clientId = options.clientId;
       this.clientSecret = options.clientSecret;
+      this.offsetNewest = options.offsetNewest || false;
     } else {
       throw new Error('Required options missing, see debug log');
     }
@@ -277,6 +278,11 @@ class Subscriber {
    */
   get stream() {
     // Create a new subscription and return the raw stream
+    const metadata = new grpc.Metadata();
+    if (this.offsetNewest) {
+      metadata.add('offset-newest', 'true');
+    }
+
     const creds = getCreds(this.uaaUrl, this.clientId, this.clientSecret, this.zoneIdProp, this.zoneId);
     const client = new eventhub_proto.Subscriber(this.uri, creds);
 
@@ -286,7 +292,7 @@ class Subscriber {
       zone_id: this.zoneId,
       subscriber: this.name,
       instance_id: this.instance
-    });
+    }, metadata);
 
     s.on('close', () => {
       debug('Subscribe stream closed');


### PR DESCRIPTION
Hi,

I just extended eventhub Subscriber with an offsetNewest flag. If it's true the subscriber sends a new header ('offset-newest': 'true') via grpc. This means the client is only gets the events fired after the subscription. The same functionality is implemented in the java client.
The change doesn't breaks the original api, just extending it. 
We already using this flag in our product but further testing is probably required.

If I can help please let me know!

Thanks,
Tibor