### PR TITLE
Adding a string type check before stringifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,11 @@ class Publisher {
       this.postStream = this.stream;
     }
 
+    // Ensure the body is a string
+    if (typeof eventBody !== 'string') {
+      eventBody = JSON.stringify(eventBody);
+    }
+
     // Ensure all tag values are strings
     const sTags = Object.keys(tags || {}).reduce((o, k) => {
       o[k] = '' + tags[k];
@@ -229,7 +234,7 @@ class Publisher {
       messages: {
         msg: [{
           id: uuidv4(),
-          body: Buffer.from(JSON.stringify(eventBody), 'utf-8'),
+          body: Buffer.from(eventBody, 'utf-8'),
           zone_id: this.zoneId,
           tags: sTags,
           timestamp: {


### PR DESCRIPTION
Preventing strings from being stringified. Strings provided to the function result JSON.stringified strings, ie double wrapped in quotes.

For example, sending Hello, world! would result in "Hello, world!" being received, including the quotes.

Providing a Buffer directly is the better solution, as user data isn't always JSON or strings, and the EH GRPC contract expects a Buffer.